### PR TITLE
Add Reusable Files for the CardinalKit Project

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+#
+# This source file is part of the CardinalKit open-source project
+#
+# SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: 🐛 Bug report
+description: File a bug report
+title: ""
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Please provide a description of the bug you encountered.
+      placeholder: A clear and concise description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Please provide a description of how to reproduce the bug.
+      placeholder: A description of how to reproduce the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: expectedbehavior
+    attributes:
+      label: Expected behavior
+      description: Please provide a clear and concise description of what you expected to happen.
+      placeholder: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: additionalcontext
+    attributes:
+      label: Additional context
+      description: Please provide any additional context that might be relevant for your bug report.
+      placeholder: Any additional context that might be relevant for your bug report.
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct and Contributing Guidelines
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+#
+# This source file is part of the CardinalKit open-source project
+#
+# SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/internal_change.yml
+++ b/.github/ISSUE_TEMPLATE/internal_change.yml
@@ -1,0 +1,47 @@
+#
+# This source file is part of the CardinalKit open-source project
+#
+# SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: 💾 Internal change
+description: Suggest an internal improvement for this project
+title: ""
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest an internal improvement for this project!
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Please provide a description of the problem the improvement will address.
+      placeholder: A description of the problem the improvement will address.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Solution
+      description: Please provide a clear and concise description of the improvement and how it should work.
+      placeholder: A clear and concise description of the improvement and how it should work.
+    validations:
+      required: true
+  - type: textarea
+    id: additionalcontext
+    attributes:
+      label: Additional context
+      description: Please provide any additional context that might be relevant for your improvement.
+      placeholder: Any additional context that might be relevant for your improvement.
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct and Contributing Guidelines
+          required: true

--- a/.github/ISSUE_TEMPLATE/major_feature.yml
+++ b/.github/ISSUE_TEMPLATE/major_feature.yml
@@ -1,0 +1,63 @@
+#
+# This source file is part of the CardinalKit open-source project
+#
+# SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: 🚀 Major feature request
+description: Suggest a new idea for this project
+title: ""
+labels: ["enhancement", "major version bump"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to share the major feature request!
+  - type: textarea
+    id: usecase
+    attributes:
+      label: Use Case
+      description: Please provide a description of the use case or context in which the feature will be used.
+      placeholder: A clear and concise description of the use case or context in which the feature will be used.
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Please provide a description of the problem the feature will address.
+      placeholder: A description of the problem the feature will address.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Solution
+      description: Please provide a clear and concise description of the feature and how it should work.
+      placeholder: A clear and concise description of the feature and how it should work.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Please provide a clear and concise description of any alternative solutions or features you've considered. Is there already software that has the behavior you're interested in? What is it, and how does it work?
+      placeholder: A clear and concise description of any alternative solutions or features you've considered. Is there already software that has the behavior you're interested in? What is it, and how does it work?
+    validations:
+      required: true
+  - type: textarea
+    id: additionalcontext
+    attributes:
+      label: Additional context
+      description: Please provide any additional context that might be relevant for your feature report
+      placeholder: Any additional context that might be relevant for your feature report
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct and Contributing Guidelines
+          required: true

--- a/.github/ISSUE_TEMPLATE/minor_feature.yml
+++ b/.github/ISSUE_TEMPLATE/minor_feature.yml
@@ -1,0 +1,47 @@
+#
+# This source file is part of the CardinalKit open-source project
+#
+# SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: 🏎 Minor feature request
+description: Suggest an improvement for this project
+title: ""
+labels: ["enhancement", "minor version bump"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to share the minor feature request!
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Please provide a description of the problem the feature will address.
+      placeholder: A description of the problem the feature will address.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Solution
+      description: Please provide a clear and concise description of the feature and how it should work.
+      placeholder: A clear and concise description of the feature and how it should work.
+    validations:
+      required: true
+  - type: textarea
+    id: additionalcontext
+    attributes:
+      label: Additional context
+      description: Please provide any additional context that might be relevant for your feature report.
+      placeholder: Any additional context that might be relevant for your feature report.
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct and Contributing Guidelines
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+<!--
+
+This source file is part of the CardinalKit open-source project
+
+SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT
+
+-->
+
+# *Name of the PR*
+
+## :recycle: Current situation & Problem
+*Describe the current situation (if possible, with an exemplary (or real) code snippet and/or where this is used)*
+*Please link any open issue that is addressed with this PR*
+
+## :bulb: Proposed solution
+*Describe the solution and how this affects the project and internal structure*
+
+## :gear: Release Notes 
+*Add a summary of the feature and possible migration guides if this is a breaking change so this section can be added to the release notes.*
+*Include code snippets that provide examples of the feature implemented if it appends or changes the public interface.*
+
+## :heavy_plus_sign: Additional Information
+*Provide some additional information if possible*
+
+### Related PRs
+*Reference the related PRs*
+
+### Testing
+*Are there tests included? If yes, which situations are tested, and which corner cases are missing?*
+
+### Reviewer Nudging
+*Where should the reviewer start? Where is a good entry point?*
+
+### Code of Conduct & Contributing Guidelines 
+
+By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md):
+- [ ] I agree to follow the [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md).
+

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+#
+# This source file is part of the CardinalKit open-source project
+#
+# SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+changelog:
+  exclude:
+    authors:
+      - PaulsAutomationBot
+  categories:
+    - title: Semantic Version Major
+      labels:
+        - major version bump
+    - title: Semantic Version Minor
+      labels:
+        - bug
+        - enhancement
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,72 @@
+#
+# This source file is part of the CardinalKit open-source project
+#
+# SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: Build and Test
+
+on:
+  workflow_call:
+    inputs:
+      packagename:
+        description: 'Name of the package passed to Xcode on macOS builds. Required for generating a test coverage or testing the DoC documentation generation'
+        required: true
+        type: string
+      path:
+        description: 'The path where the Swift Package is located. Defaults to $GITHUB_WORKSPACE'
+        required: false
+        type: string
+        default: '.'
+      test:
+        description: 'A flag indicating if the Swift package contains tests'
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  macos:
+    name: macOS ${{ matrix.configuration }}
+    runs-on: macos-12
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration: [debug, release, release_testing]
+    defaults:
+      run:
+        working-directory: ${{ inputs.path }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+    - name: Check Environment
+      run: |
+          xcodebuild -version
+          swift --version
+          echo "inputs.packagename: ${{ inputs.packagename }}"
+          echo "inputs.path: ${{ inputs.path }}"
+          echo "inputs.testdocc: ${{ inputs.testdocc }}"
+          echo "matrix.configuration: ${{ matrix.configuration }}"
+          echo "cache key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}"
+    - uses: actions/cache@v3
+      with:
+        path: .build
+        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+    - name: Release Build
+      if: matrix.configuration == 'release'
+      run: swift build -c release
+    - name: Release Build & Test
+      if: matrix.configuration == 'release_testing' && inputs.test
+      run: swift test -c release -Xswiftc -enable-testing -Xswiftc -DRELEASE_TESTING
+    - name: Debug Build & Test
+      if: matrix.configuration == 'debug' && inputs.test
+      run: swift test -c debug --enable-code-coverage -Xswiftc -DCOVERAGE
+    - name: Convert coverage report
+      if: matrix.configuration == 'debug' && inputs.test
+      run: xcrun llvm-cov export -format="lcov" .build/debug/${{ inputs.packagename }}PackageTests.xctest/Contents/MacOS/${{ inputs.packagename }}PackageTests -instr-profile .build/debug/codecov/default.profdata > coverage.lcov
+    - name: Upload coverage to Codecov
+      if: matrix.configuration == 'debug' && inputs.test
+      uses: codecov/codecov-action@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,61 @@
+#
+# This source file is part of the CardinalKit open-source project
+#
+# SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: Generate DocC Documentation
+
+on:
+  workflow_call:
+    inputs:
+      targetname:
+        description: 'Name of the Swift Package Manager target using DocC'
+        required: true
+        type: string
+
+jobs:
+  generate:
+    name: Generate DocC Documentation
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v3
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+    - uses: actions/cache@v2
+      with:
+        path: .build
+        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+    - name: Check Environment
+      run: |
+          xcodebuild -version
+          swift --version
+          echo "inputs.targetname: ${{ inputs.targetname }}"
+          echo "github.event.repository.name: ${{ github.event.repository.name }}"
+    - name: Generate Documentation
+      run: |
+          swift package --allow-writing-to-directory ./docs \
+            generate-documentation --target ${{ inputs.targetname }} \
+            --disable-indexing \
+            --transform-for-static-hosting \
+            --hosting-base-path ${{ github.event.repository.name }} \
+            --output-path ./docs
+    - uses: actions/upload-pages-artifact@v1
+      with:
+        path: ./docs
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: generate
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,0 +1,21 @@
+#
+# This source file is part of the CardinalKit open-source project
+#
+# SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: REUSE Compliance Check
+
+on:
+  workflow_call:
+
+jobs:
+  reuse:
+    name: REUSE Compliance Check
+    runs-on: ubuntu-latest
+    steps: 
+    - uses: actions/checkout@v3
+    - name: REUSE Compliance Check
+      uses: fsfe/reuse-action@v1

--- a/.github/workflows/spm-update.yml
+++ b/.github/workflows/spm-update.yml
@@ -1,0 +1,64 @@
+#
+# This source file is part of the CardinalKit open-source project
+#
+# SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: Swift Package Update
+
+on:
+  workflow_call:
+    inputs:
+      author:
+        description: 'The author of the resulting PR containing the updated Swift package'
+        required: false
+        type: string
+        default: PaulsAutomationBot
+      reviewers:
+        description: 'The reviewers of the resulting pull request containing the updated Swift package'
+        required: false
+        type: string
+        default: PSchmiedmayer
+      branch:
+        description: 'The branch that should be used to create the pull request'
+        required: false
+        type: string
+        default: bots/update-dependencies
+    secrets:
+      token:
+        description: 'The Personal Access Token with permissions to push to the repository. Unfortunately, the GITHUB_TOKEN does not trigger GitHub Actions in the resulting pull request.'
+        required: true
+  
+jobs:
+  createPR:
+    name: Create Pull Request
+    container:
+      image: swift:focal
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Check Environment
+      run: |
+          swift --version
+          echo "inputs.author: ${{ inputs.author }}"
+          echo "inputs.reviewers: ${{ inputs.reviewers }}"
+          echo "inputs.branch: ${{ inputs.branch }}"
+    - name: Update Swift Packages
+      run: swift package update
+    - name: Add Safe Directory
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+    - uses: peter-evans/create-pull-request@v4
+      with:
+        token: ${{ secrets.token }}
+        commit-message: Update dependencies
+        title: Update dependencies
+        body: Update the Swift Package dependencies.
+        delete-branch: true
+        base: develop
+        branch: bots/update-dependencies
+        assignees: ${{ inputs.author }}
+        committer: ${{ inputs.author }} <${{ inputs.author }}@users.noreply.github.com>
+        author: ${{ inputs.author }} <${{ inputs.author }}@users.noreply.github.com>
+        reviewers: ${{ inputs.reviewers }}

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -1,0 +1,28 @@
+#
+# This source file is part of the CardinalKit open-source project
+#
+# SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: SwiftLint
+
+on:
+  workflow_call:
+
+jobs:
+  swiftlint:
+    name: SwiftLint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: SwiftLint
+        uses: sinoru/actions-swiftlint@v6
+        with:
+          swiftlint-version: 'main'
+          swiftlint-args: --strict
+        env:
+          DIFF_BASE: ${{ github.base_ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+#
+# This source file is part of the CardinalKit open-source project
+#
+# SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+.DS_Store
+.env

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,142 @@
+<!--
+
+This source file is part of the CardinalKit open-source project
+
+SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT
+
+-->
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Using welcoming and inclusive language
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at cardinalkit@stanford.edu.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+[https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0].
+
+Community Impact Guidelines were inspired by 
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available 
+at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.0]: https://www.contributor-covenant.org/version/2/0/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+<!--
+
+This source file is part of the CardinalKit open-source project
+
+SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT
+
+-->
+
+# Contributing Guidelines
+
+Thank you for contributing to the CardinalKit project! We value the time and effort you invest in the open-source project!
+
+We use [GitHub Discussions](https://docs.github.com/en/discussions) at [https://github.com/orgs/CardinalKit/discussions](https://github.com/orgs/CardinalKit/discussions) for any discussions about the project.
+Please follow our [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md).
+
+We use the [Github Flow](https://guides.github.com/introduction/flow/index.html) for all code-related contributions.
+GitHub discussions are the best way to brainstorm your suggestions. 
+GitHub issues are the best way to document decisions or bugs.
+Pull requests are the best way to propose changes to the codebase.
+
+## Licensing
+
+Your submissions must be published and conform to the license currently used in the respective repository.
+
+## Bug Reporting
+
+We use GitHub issues to track public bugs. Report a bug by opening a new issue using the bug issue template.
+
+## Support Policy
+
+Please refer to our [Support Policy](https://github.com/CardinalKit/.github/blob/main/SUPPORT.md) for information about getting support. 
+
+## Security Policy
+
+For security and vulnerability-related issues, please refer to our [Support Policy](https://github.com/CardinalKit/.github/blob/main/SUPPORT.md).

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,6 +8,7 @@ SPDX-License-Identifier: MIT
 
 -->
 
-# .github
+# CardinalKit .github Contributors
 
-This repository serves as a collection of default community health files, GitHub Action workflows, templates, and information for the CardinalKit organization.
+* [Vishnu Ravi](https://github.com/vishnuravi)
+* [Paul Schmiedmayer](https://github.com/PSchmiedmayer)

--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,0 +1,9 @@
+#
+# This source file is part of the CardinalKit open-source project
+#
+# SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+custom: ["https://cardinalkit.stanford.edu", cardinalkit.stanford.edu]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+<!--
+
+This source file is part of the CardinalKit open-source project
+
+SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT
+
+-->
+
+# Security Policy
+
+Please report security vulnerabilities to the CardinalKit core team at cardinalkit@stanford.edu.
+We highly value your input and will get back to you as soon as possible. Please include steps to reproduce, context, and any further information that makes identifying and resolving the vulnerability as quickly as possible.
+
+See the [The CERT Guide to Coordinated Vulnerability Disclosure](https://vuls.cert.org/confluence/display/CVD/The+CERT+Guide+to+Coordinated+Vulnerability+Disclosure) for additional background information about the coordinated vulnerability disclosure process.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,18 @@
+<!--
+
+This source file is part of the CardinalKit open-source project
+
+SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT
+
+-->
+
+# Support Policy
+
+We use [GitHub Discussions](https://docs.github.com/en/discussions) for any questions that you have about the project.
+Please use [https://github.com/orgs/CardinalKit/discussions](https://github.com/orgs/CardinalKit/discussions) to ask questions, share your CardinalKit projects, and follow announcements.
+
+Please follow our [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md).
+
+Please refer to our [Security Policy](https://github.com/CardinalKit/.github/blob/main/SECURITY.md) for all security-related issues.

--- a/assets/CK_Map.jpg.license
+++ b/assets/CK_Map.jpg.license
@@ -1,0 +1,5 @@
+This source file is part of the CardinalKit open-source project
+
+SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT

--- a/assets/ck-footer-dark.png.license
+++ b/assets/ck-footer-dark.png.license
@@ -1,0 +1,5 @@
+This source file is part of the CardinalKit open-source project
+
+SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT

--- a/assets/ck-footer-light.png.license
+++ b/assets/ck-footer-light.png.license
@@ -1,0 +1,5 @@
+This source file is part of the CardinalKit open-source project
+
+SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT

--- a/assets/ck-header-dark.png.license
+++ b/assets/ck-header-dark.png.license
@@ -1,0 +1,5 @@
+This source file is part of the CardinalKit open-source project
+
+SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT

--- a/assets/ck-header-light.png.license
+++ b/assets/ck-header-light.png.license
@@ -1,0 +1,5 @@
+This source file is part of the CardinalKit open-source project
+
+SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,12 +1,22 @@
+<!--
+
+This source file is part of the CardinalKit open-source project
+
+SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT
+
+-->
+
 ![CardinalKit Logo](https://raw.githubusercontent.com/CardinalKit/.github/main/assets/ck-header-light.png#gh-light-mode-only)
 ![CardinalKit Logo](https://raw.githubusercontent.com/CardinalKit/.github/main/assets/ck-header-dark.png#gh-dark-mode-only)
 
 ### Open-source Framework for Rapid Development of Modern Interoperable Digital Health Applications
 
-We provide you a suite of tools to build your digital health experience from the ground up, from the app itself to storing collected data in the cloud. 
+We provide you with a suite of tools to build your digital health experience from the ground up, from the template applications to storing collected data in the cloud.
 
-- [iOS app](https://github.com/cardinalkit/cardinalkit)
-- [Android app](https://github.com/cardinalkit/cardinalkit-android)
+- [iOS Template Application](https://github.com/cardinalkit/cardinalkit)
+- [Android Template Application](https://github.com/cardinalkit/cardinalkit-android)
 - [Web Dashboard](https://github.com/cardinalkit/cardinalkit-web-dashboard)
 
 For more information, check out our website at [cardinalkit.org](https://cardinalkit.org) or our [getting started](https://cardinalkit.org/cardinalkit-docs/) guide!


### PR DESCRIPTION
# Add Reusable Files for the CardinalKit Project

## :recycle: Current situation & Problem
Each CardinalKit repository contains a varying degree of community health files, GitHub actions, and templates. This PR addresses this issue.

## :bulb: Proposed solution
The .github repository allows the reusability of various GitHub configuration files as described in the GitHub documentation: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file

## :gear: Release Notes 
This PR adds various reusable files for the CardinalKit project:
- Reusable GitHub Action Workflows
- Various community health files
- Issue templates and pull request templates for the project
- Licensing and clarification improvements.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md).