### PR TITLE
Add a Scheme Parameter to the Xcodebuild-based SPM Actions

### DIFF
--- a/.github/workflows/build-and-test-xcodebuild-spm.yml
+++ b/.github/workflows/build-and-test-xcodebuild-spm.yml
@@ -16,8 +16,13 @@ on:
         required: false
         type: string
         default: '.'
-      packagename:
-        description: 'Name of the package passed to xcodebuild on macOS builds. Required for generating a test coverage or testing the DoC documentation generation'
+      scheme:
+        description: 'Name of the Scheme used to build the Swift Package'
+        required: false
+        type: string
+        default: ''
+      targetname:
+        description: 'Name of the target in the Swift Package. Required for generating a test coverage.'
         required: true
         type: string
 
@@ -37,19 +42,22 @@ jobs:
       run: |
           xcodebuild -version
           swift --version
-          echo "inputs.packagename: ${{ inputs.packagename }}"
           echo "inputs.path: ${{ inputs.path }}"
+          echo "inputs.scheme: ${{ inputs.scheme }}"
+          echo "inputs.targetname: ${{ inputs.targetname }}"
     - name: Build and Test
       run: |
+          INPUT_SCHEME=${{ inputs.scheme }}
+          SCHEME=${INPUT_SCHEME:-"${{ inputs.targetname }}-Package"}
           xcodebuild test \
-            -scheme ${{ inputs.packagename }}-Package \
+            -scheme $SCHEME \
             -sdk iphonesimulator \
             -destination "name=iPhone 14 Pro Max" \
             -enableCodeCoverage YES \
-            -resultBundlePath ${{ inputs.packagename }}.xcresult \
+            -resultBundlePath ${{ inputs.targetname }}.xcresult \
             CODE_SIGNING_ALLOWED="NO"
     - name: Upload Artifact
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ inputs.packagename }}.xcresult
-        path: ${{ inputs.packagename }}.xcresult
+        name: ${{ inputs.targetname }}.xcresult
+        path: ${{ inputs.targetname }}.xcresult

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,11 @@ name: Generate DocC Documentation Using the Swift Package Manager
 on:
   workflow_call:
     inputs:
+      scheme:
+        description: 'Name of the Scheme used to build the documentation'
+        required: false
+        type: string
+        default: ''
       targetname:
         description: 'Name of the Swift Package Manager target using DocC'
         required: true
@@ -39,6 +44,7 @@ jobs:
       run: |
           xcodebuild -version
           swift --version
+          echo "inputs.scheme: ${{ inputs.scheme }}"
           echo "inputs.targetname: ${{ inputs.targetname }}"
           echo "github.event.repository.name: ${{ github.event.repository.name }}"
     - name: Generate Documentation
@@ -53,8 +59,10 @@ jobs:
     - name: Generate Documentation Using Xcodebuild
       if: inputs.usexcodebuild
       run: |
+          INPUT_SCHEME=${{ inputs.scheme }}
+          SCHEME=${INPUT_SCHEME:-"${{ inputs.targetname }}-Package"}
           xcodebuild docbuild \
-            -scheme ${{ inputs.targetname }}-Package \
+            -scheme $SCHEME \
             -sdk iphonesimulator \
             -destination "name=iPhone 14 Pro Max" \
             -derivedDataPath .xcodebuild/ \


### PR DESCRIPTION
# Add a Scheme Parameter to the Xcodebuild-based SPM Actions

## :recycle: Current situation & Problem
Some projects might not have multiple products in a Swift Package, resulting that reasonable the scheme name doesn't include the "-Package" postfix.

## :bulb: Proposed solution
This PR adds a way to explicitly pass in the scheme to the GitHub Action.

## :gear: Release Notes 
- You can now pass the `scheme` parameter to `docs.yml` and `build-and-test-xcodebuild-spm.yml`

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md).

