### PR TITLE
Add a GitHub Action to Build and Push a Docker Image

### DIFF
--- a/.github/workflows/docker-build-and-push
+++ b/.github/workflows/docker-build-and-push
@@ -1,0 +1,118 @@
+#
+# This source file is part of the CardinalKit open-source project
+#
+# SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: Docker Build and Push
+
+on:
+  workflow_call:
+    inputs:
+      docker-file:
+        description: 'Path or name of the Docker file. The default values is `Dockerfile`. The docker file can use the `baseimage` to get an architecture specific Swift base image'
+        required: false
+        type: string
+        default: 'Dockerfile'
+      image-name:
+        description: 'The name used to tag the docker image on ghcr.io containing the organzation/account name and the name of the image, e.g.: apodini/example'
+        required: true
+        type: string
+      working-directory:
+        description: 'The working-directory of the GitHub Action. Defaults to $GITHUB_WORKSPACE'
+        required: false
+        type: string
+        default: '.'
+
+jobs:
+  dockerARM64:
+    name: Docker Build and Push Image ARM64
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Get latest tag
+        id: latesttag
+        uses: WyriHaximus/github-action-get-previous-tag@v1
+        with:
+          fallback: latest
+      - name: Log in to the container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push docker image
+        id: buildandpush
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/arm64
+          file: ${{ inputs.docker-file }}
+          push: true
+          tags: ghcr.io/${{ inputs.image-name }}:latest-arm64,ghcr.io/${{ inputs.image-name }}:${{ steps.latesttag.outputs.tag }}-arm64
+  dockerAMD64:
+    name: Docker Build and Push Image AMD64
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Get latest tag
+        id: latesttag
+        uses: WyriHaximus/github-action-get-previous-tag@v1
+        with:
+          fallback: latest
+      - name: Log in to the container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push docker image
+        id: buildandpush
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ${{ inputs.docker-file }}
+          push: true
+          tags: ghcr.io/${{ inputs.image-name }}:latest-amd64,ghcr.io/${{ inputs.image-name }}:${{ steps.latesttag.outputs.tag }}-amd64
+  dockermanifest:
+    needs: [dockerARM64, dockerAMD64]
+    name: Create Multi-CPU Architecture Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Get latest tag
+        id: latesttag
+        uses: WyriHaximus/github-action-get-previous-tag@v1
+        with:
+          fallback: latest
+      - name: Log in to the container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and Push Multi Architecture Image
+        run: |
+            docker manifest create ghcr.io/${{ inputs.image-name }}:latest \
+              --amend ghcr.io/${{ inputs.image-name }}:latest-amd64 \
+              --amend ghcr.io/${{ inputs.image-name }}:latest-arm64
+            docker manifest create ghcr.io/${{ inputs.image-name }}:${{ steps.latesttag.outputs.tag }} \
+              --amend ghcr.io/${{ inputs.image-name }}:${{ steps.latesttag.outputs.tag }}-amd64 \
+              --amend ghcr.io/${{ inputs.image-name }}:${{ steps.latesttag.outputs.tag }}-arm64
+            docker manifest push ghcr.io/${{ inputs.image-name }}:latest
+            docker manifest push ghcr.io/${{ inputs.image-name }}:${{ steps.latesttag.outputs.tag }}

--- a/profile/README.md
+++ b/profile/README.md
@@ -17,7 +17,6 @@ We provide you with a suite of tools to build your digital health experience fro
 
 - [iOS Template Application](https://github.com/cardinalkit/cardinalkit)
 - [Android Template Application](https://github.com/cardinalkit/cardinalkit-android)
-- [Web Dashboard](https://github.com/cardinalkit/cardinalkit-web-dashboard)
 
 For more information, check out our website at [cardinalkit.org](https://cardinalkit.org) or our [getting started](https://cardinalkit.org/cardinalkit-docs/) guide!
 


### PR DESCRIPTION
# Add a GitHub Action to Build and Push a Docker Image

## :recycle: Current situation & Problem
Repositories with a docker image can use this GitHub Action to build and push a Docker image to the GitHub Docker registry. 

## :bulb: Proposed solution
Adds a GitHub Action to build and push a Docker image to the GitHub Docker registry.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md).

