### PR TITLE
Define a Fixed Version of SwiftLint That Should Be Used

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -22,5 +22,5 @@ jobs:
       - name: SwiftLint
         uses: sinoru/actions-swiftlint@v6
         with:
-          swiftlint-version: 'main'
+          swiftlint-version: '0.49.1'
           swiftlint-args: --strict


### PR DESCRIPTION
# Define a Fixed Version of SwiftLint That Should Be Used

## :recycle: Current situation & Problem
SwiftLint runs are currently not reproducible as they action uses whatever code is found at the main branch of the SwiftLint repo.

## :bulb: Proposed solution
We fix the SwiftLint version to a well defined version.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md).

