### PR TITLE
Fix Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,7 @@
 
 name: 🐛 Bug report
 description: File a bug report
-title: ""
+title: "🐛 Bug report: Remove this title with a descriptive title."
 labels: ["bug"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,3 +7,10 @@
 #
 
 blank_issues_enabled: false
+contact_links:
+  - name: Discussions & Support
+    url: https://github.com/orgs/CardinalKit/discussions
+    about: We use GitHub Discussions for any discussions and support.
+  - name: Security & Vulnerability-related Issues
+    url: https://github.com/CardinalKit/.github/blob/main/SECURITY.md
+    about: For security and vulnerability-related issues, please refer to our Security Policy.

--- a/.github/ISSUE_TEMPLATE/internal_change.yml
+++ b/.github/ISSUE_TEMPLATE/internal_change.yml
@@ -8,7 +8,7 @@
 
 name: 💾 Internal change
 description: Suggest an internal improvement for this project
-title: ""
+title: "💾 Internal change: Remove this title with a descriptive title."
 labels: ["enhancement"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/major_feature.yml
+++ b/.github/ISSUE_TEMPLATE/major_feature.yml
@@ -8,7 +8,7 @@
 
 name: 🚀 Major feature request
 description: Suggest a new idea for this project
-title: ""
+title: "🚀 Major feature request: Remove this title with a descriptive title."
 labels: ["enhancement", "major version bump"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/minor_feature.yml
+++ b/.github/ISSUE_TEMPLATE/minor_feature.yml
@@ -8,7 +8,7 @@
 
 name: 🏎 Minor feature request
 description: Suggest an improvement for this project
-title: ""
+title: "🏎 Minor feature request: Remove this title with a descriptive title."
 labels: ["enhancement", "minor version bump"]
 body:
   - type: markdown


### PR DESCRIPTION
# Fix Issue Templates

## :recycle: Current situation & Problem
Fixes the syntax of the issue templates that were missing a valid title.

## :bulb: Proposed solution
Adds a descriptive title to the issue templates.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md).

