### PR TITLE
Simplify SPM Xcodebuild GitHub Action 

### DIFF
--- a/.github/workflows/build-and-test-xcodebuild-spm.yml
+++ b/.github/workflows/build-and-test-xcodebuild-spm.yml
@@ -21,10 +21,6 @@ on:
         required: false
         type: string
         default: ''
-      targetname:
-        description: 'Name of the target in the Swift Package. Required for generating a test coverage.'
-        required: true
-        type: string
 
 jobs:
   build_and_test:
@@ -44,20 +40,17 @@ jobs:
           swift --version
           echo "inputs.path: ${{ inputs.path }}"
           echo "inputs.scheme: ${{ inputs.scheme }}"
-          echo "inputs.targetname: ${{ inputs.targetname }}"
     - name: Build and Test
       run: |
-          INPUT_SCHEME=${{ inputs.scheme }}
-          SCHEME=${INPUT_SCHEME:-"${{ inputs.targetname }}-Package"}
           xcodebuild test \
-            -scheme $SCHEME \
+            -scheme ${{ inputs.scheme }} \
             -sdk iphonesimulator \
             -destination "name=iPhone 14 Pro Max" \
             -enableCodeCoverage YES \
-            -resultBundlePath ${{ inputs.targetname }}.xcresult \
+            -resultBundlePath ${{ inputs.scheme }}.xcresult \
             CODE_SIGNING_ALLOWED="NO"
     - name: Upload Artifact
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ inputs.targetname }}.xcresult
-        path: ${{ inputs.targetname }}.xcresult
+        name: ${{ inputs.scheme }}.xcresult
+        path: ${{ inputs.scheme }}.xcresult


### PR DESCRIPTION
# Simplify SPM Xcodebuild GitHub Action 

## :recycle: Current situation & Problem
The SPM Xcodebuild GitHub Action currently uses a `scheme` and `targetname` parameter that are not used independently. 

## :bulb: Proposed solution
This PR reduces the number of PRs.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md).

