### PR TITLE
Upload Artifacts On Test Failure

### DIFF
--- a/.github/workflows/build-and-test-xcodebuild.yml
+++ b/.github/workflows/build-and-test-xcodebuild.yml
@@ -54,6 +54,7 @@ jobs:
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO
     - name: Upload Artifact
+      if: always()
       uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.scheme }}.xcresult


### PR DESCRIPTION
# Upload Artifacts On Test Failure

## :recycle: Current situation & Problem
If a test fails, we don't get access to the test result bundles.

## :bulb: Proposed solution
This PR enables the upload of test results independent of the outcome of the test.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md).

